### PR TITLE
[refact] - 스크린리더 접근성 개선

### DIFF
--- a/src/components/recommendedItem/recommendedItem.test.tsx
+++ b/src/components/recommendedItem/recommendedItem.test.tsx
@@ -8,27 +8,25 @@ jest.mock("next/router", () => require("next-router-mock"));
 
 describe("<recommendedItem />", () => {
     const renderComponent = (props: RecommendedItemType) => {
-        const { getByRole, getByLabelText, queryByLabelText } = render(
-            <RecommendedItem {...props} />,
-            { wrapper: MemoryRouterProvider }
-        );
+        const { getByRole, getByLabelText, queryByLabelText, getByTestId } =
+            render(<RecommendedItem {...props} />, {
+                wrapper: MemoryRouterProvider,
+            });
 
         const thumnail = getByRole("img");
-        const reviewIcon = getByLabelText("리뷰 아이콘");
-        const productName = getByLabelText("상품이름");
-        const discountRate = queryByLabelText("할인율");
-        const productPrice = getByLabelText("상품가격");
-        const comentLength = getByLabelText("리뷰숫자");
-        const productDescribe = getByLabelText("상품설명");
-        const addToCartIcon = getByLabelText("상품을 카트에 추가하는 아이콘");
-        const beforDiscountPrice = getByLabelText("할인전가격");
+        const productName = getByTestId("상품이름");
+        const productPrice = getByLabelText(/가격/);
+        const comentLength = getByLabelText(/리뷰/);
+        const productDescribe = getByTestId("상품설명");
+        const addToCartIcon = getByTestId("카트추가아이콘");
+        const beforDiscountPrice = getByTestId("할인전가격");
+        const reviewIcon = getByTestId("reviewIcon");
 
         return {
             thumnail,
             reviewIcon,
             productName,
             productPrice,
-            discountRate,
             addToCartIcon,
             comentLength,
             productDescribe,
@@ -43,7 +41,6 @@ describe("<recommendedItem />", () => {
         expect(el.thumnail).toBeInTheDocument();
         expect(el.reviewIcon).toBeInTheDocument();
         expect(el.productName).toBeInTheDocument();
-        expect(el.discountRate).toBeInTheDocument();
         expect(el.productPrice).toBeInTheDocument();
         expect(el.comentLength).toBeInTheDocument();
         expect(el.addToCartIcon).toBeInTheDocument();

--- a/src/components/recommendedItem/recommendedItem.tsx
+++ b/src/components/recommendedItem/recommendedItem.tsx
@@ -19,34 +19,39 @@ export const RecommendedItem = (props: RecommendedItemType) => {
     return (
         <Container href={`/product/${props.id}`}>
             <ImageContainer>
-                <img src={props.imgUrl} alt={props.name + "제품 이미지"} />
-                <CartIcon aria-label="상품을 카트에 추가하는 아이콘">
+                <img src={props.imgUrl} alt="" />
+                <CartIcon data-testid="카트추가아이콘">
                     <BsCart2 size="23px" />
                 </CartIcon>
             </ImageContainer>
-            <ProductDescribe aria-label="상품설명">
+            <ProductDescribe aria-hidden={true} data-testid="상품설명">
                 {props.description}
             </ProductDescribe>
-            <ProductName aria-label="상품이름">{props.name}</ProductName>
+            <ProductName data-testid="상품이름">{props.name}</ProductName>
             <PriceInfoContainer>
-                {props.disCountRate && (
-                    <DisCountRate aria-label="할인율">
+                {props.disCountRate > 0 && (
+                    <DisCountRate aria-label={`할인율${props.disCountRate}%`}>
                         {props.disCountRate}%
                     </DisCountRate>
                 )}
-                <Price aria-label="상품가격">
+                <Price aria-label={`가격${props.price}원`}>
                     {addCommaToNumber(props.price)}원
                 </Price>
             </PriceInfoContainer>
-            <BeforDiscountRate aria-label="할인전가격">
+            <BeforDiscountRate aria-hidden={true} data-testid="할인전가격">
                 {addCommaToNumber(props.beforeDiscountPrice)}원
             </BeforDiscountRate>
             <ReviewContainer>
                 <i>
-                    <BiMessageSquareDots size={15} aria-label="리뷰 아이콘" />
+                    <BiMessageSquareDots size={15} />
                 </i>
                 <p>후기</p>
-                <span aria-label="리뷰숫자">{props.comentLength}</span>
+                <span
+                    aria-label={`리뷰${props.comentLength}개`}
+                    data-testid="reviewIcon"
+                >
+                    {props.comentLength}
+                </span>
             </ReviewContainer>
         </Container>
     );


### PR DESCRIPTION
- 수정 전
aria-label 속성을 테스트 코드에서 element 선택자로 사용

- 수정 후
aria-label을 스크린 리더 접근성을 위해 사용하도록 개선
테스트 위한 속성으로 data-testid속성으로 변경
필요없는 데이터 aria-hidden 속성으로 처리